### PR TITLE
Fix typo in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -90,7 +90,7 @@ To start the SSE development server, run:
 ./start_remote_dev_server.sh
 ```
 
-For convenience, we also prove a lightweight MCP Client to connect to SSE servers. Usage:
+For convenience, we also provide a lightweight MCP Client to connect to SSE servers. Usage:
 
 ```bash
 python tests/clients/RemoteMCPTestClient.py --endpoint=http://localhost:8000/simple-tools-server/local


### PR DESCRIPTION
Change "prove" to "provide".

## Original text

For convenience, we also _**prove**_ a lightweight MCP Client to connect to SSE servers.

## Updated text

For convenience, we also _**provide**_ a lightweight MCP Client to connect to SSE servers.