### PR TITLE
[GMLP-2902] Add output schema for every MCP server

### DIFF
--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -62,14 +62,16 @@ async def format_message(slack_client, message, channel_id):
     """Format a Slack message for display"""
     text = message.get("text", "")
     user_id = message.get("user", "Unknown")
-    
+
     # Get user name if possible
     user_name = "Unknown"
     if user_id != "Unknown":
         try:
             user_info = slack_client.users_info(user=user_id)
             if user_info["ok"]:
-                user_name = user_info["user"].get("real_name") or user_info["user"].get("name", "Unknown")
+                user_name = user_info["user"].get("real_name") or user_info["user"].get(
+                    "name", "Unknown"
+                )
         except SlackApiError:
             pass
 
@@ -235,7 +237,9 @@ def create_server(user_id, api_key=None):
             # Format messages
             formatted_messages = []
             for message in messages:
-                formatted_messages.append(await format_message(slack_client, message, channel_id))
+                formatted_messages.append(
+                    await format_message(slack_client, message, channel_id)
+                )
 
             content = "\n".join(formatted_messages)
 
@@ -271,9 +275,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Chronologically ordered list of messages in the format: '<#channel_id> user_name: message_text'",
+                    "description": "Chronologically ordered list of channel messages with each line containing the channel ID, sender's username, and message content. Format: '<#channel_id> user_name: message_text'. Messages appear in the order they were sent, from oldest to newest.",
                     "examples": [
-                        "<#C08Q6PQQZSQ> testing_mcp: Test Canvas\n<#C08Q6PQQZSQ> testing_mcp: This is a test message from the MCP server!\n<#C08Q6PQQZSQ> gumloop: heyo"
+                        "<#channel_id> user1: Hello everyone\n<#channel_id> user2: Welcome to the channel\n<#channel_id> user1: Thanks for the warm welcome!"
                     ],
                 },
             ),
@@ -300,9 +304,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Confirmation message with channel ID and timestamp of the sent message",
+                    "description": "Success confirmation for message delivery with the destination channel ID in Slack format (<#channel_id>) and a unique message timestamp that can be used for threading or future message references",
                     "examples": [
-                        "Message sent successfully to <#C08Q6PQQZSQ>\nTimestamp: 1745884854.985879"
+                        "Message sent successfully to <#channel_id>\nTimestamp: 1234567890.123456"
                     ],
                 },
             ),
@@ -333,9 +337,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Confirmation message with channel ID and timestamp of the created canvas",
+                    "description": "Canvas creation confirmation containing the destination channel ID in Slack format (<#channel_id>) and a unique timestamp identifier that can be used to reference this canvas in future operations",
                     "examples": [
-                        "Canvas created successfully in <#C08Q6PQQZSQ>\nTimestamp: 1745884854.985879"
+                        "Canvas created successfully in <#channel_id>\nTimestamp: 1234567890.123456"
                     ],
                 },
             ),
@@ -387,7 +391,9 @@ def create_server(user_id, api_key=None):
 
                 formatted_messages = []
                 for message in messages:
-                    formatted_messages.append(await format_message(slack_client, message, channel))
+                    formatted_messages.append(
+                        await format_message(slack_client, message, channel)
+                    )
 
                 result = "\n".join(formatted_messages)
                 logger.info(f"Read messages result: {result}")

--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -58,32 +58,23 @@ async def create_slack_client(user_id, api_key=None):
     return WebClient(token=token)
 
 
-async def format_message(slack_client, message, channel_id):
-    """Format a Slack message for display"""
-    text = message.get("text", "")
+async def enrich_message_with_user_info(slack_client, message):
+    """Add user info to the message"""
     user_id = message.get("user", "Unknown")
 
-    # Get user name if possible
-    user_name = "Unknown"
     if user_id != "Unknown":
         try:
             user_info = slack_client.users_info(user=user_id)
             if user_info["ok"]:
-                user_name = user_info["user"].get("real_name") or user_info["user"].get(
+                user_data = user_info["user"]
+                message["user_name"] = user_data.get("real_name") or user_data.get(
                     "name", "Unknown"
                 )
+                message["user_profile"] = user_data.get("profile", {})
         except SlackApiError:
-            pass
+            message["user_name"] = "Unknown"
 
-    # If message has attachments, add them to the text
-    if "attachments" in message:
-        for attachment in message["attachments"]:
-            if "text" in attachment:
-                text += f"\n> {attachment['text']}"
-            if "title" in attachment:
-                text += f"\n> *{attachment['title']}*"
-
-    return f"<#{channel_id}> {user_name}: {text}"
+    return message
 
 
 async def get_channel_id(slack_client, server, channel_name):
@@ -234,16 +225,20 @@ def create_server(user_id, api_key=None):
             # Reverse to get chronological order
             messages.reverse()
 
-            # Format messages
-            formatted_messages = []
+            # Enrich messages with user information
+            enriched_messages = []
             for message in messages:
-                formatted_messages.append(
-                    await format_message(slack_client, message, channel_id)
+                enriched_message = await enrich_message_with_user_info(
+                    slack_client, message
                 )
+                enriched_messages.append(enriched_message)
 
-            content = "\n".join(formatted_messages)
-
-            return [ReadResourceContents(content=content, mime_type="text/plain")]
+            return [
+                ReadResourceContents(
+                    content=json.dumps(enriched_messages, indent=2),
+                    mime_type="application/json",
+                )
+            ]
 
         except SlackApiError as e:
             logger.error(f"Error reading Slack channel: {e}")
@@ -275,9 +270,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Chronologically ordered list of channel messages with each line containing the channel ID, sender's username, and message content. Format: '<#channel_id> user_name: message_text'. Messages appear in the order they were sent, from oldest to newest.",
+                    "description": "JSON array of messages with user and message details",
                     "examples": [
-                        "<#channel_id> user1: Hello everyone\n<#channel_id> user2: Welcome to the channel\n<#channel_id> user1: Thanks for the warm welcome!"
+                        '[{"user":"U12345","type":"message","ts":"1234567890.123456","text":"This is a test message","team":"T12345","user_name":"test_user","user_profile":{"real_name":"Test User","display_name":"Test User"}}, {"user":"U67890","type":"message","ts":"1234567891.123456","text":"Hello there","team":"T12345","user_name":"another_user","user_profile":{"real_name":"Another User","display_name":"Another User"}}]'
                     ],
                 },
             ),
@@ -304,9 +299,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Success confirmation for message delivery with the destination channel ID in Slack format (<#channel_id>) and a unique message timestamp that can be used for threading or future message references",
+                    "description": "JSON response containing the result of the message send operation",
                     "examples": [
-                        "Message sent successfully to <#channel_id>\nTimestamp: 1234567890.123456"
+                        '{"status":"success","channel":"C12345","ts":"1234567890.123456","message":{"user":"U12345","type":"message","ts":"1234567890.123456","text":"This is a test message","team":"T12345"}}'
                     ],
                 },
             ),
@@ -337,9 +332,9 @@ def create_server(user_id, api_key=None):
                 },
                 outputSchema={
                     "type": "string",
-                    "description": "Canvas creation confirmation containing the destination channel ID in Slack format (<#channel_id>) and a unique timestamp identifier that can be used to reference this canvas in future operations",
+                    "description": "JSON response containing the result of the canvas creation",
                     "examples": [
-                        "Canvas created successfully in <#channel_id>\nTimestamp: 1234567890.123456"
+                        '{"status":"success","channel":"C12345","ts":"1234567890.123456","message":{"user":"U12345","type":"message","ts":"1234567890.123456","text":"Test Canvas","team":"T12345","blocks":[{"type":"header","text":{"type":"plain_text","text":"Test Canvas"}},{"type":"section","text":{"type":"mrkdwn","text":"This is a test canvas message"}}]}}'
                     ],
                 },
             ),
@@ -374,9 +369,10 @@ def create_server(user_id, api_key=None):
                         slack_client, server, channel_name
                     )
                     if channel_id is None:
+                        error_response = {"error": f"Channel {channel} not found"}
                         return [
                             TextContent(
-                                type="text", text=f"Channel {channel} not found"
+                                type="text", text=json.dumps(error_response, indent=2)
                             )
                         ]
                     channel = channel_id
@@ -389,16 +385,19 @@ def create_server(user_id, api_key=None):
                 messages = response.get("messages", [])
                 messages.reverse()  # Chronological order
 
-                formatted_messages = []
+                # Enrich messages with user information
+                enriched_messages = []
                 for message in messages:
-                    formatted_messages.append(
-                        await format_message(slack_client, message, channel)
+                    enriched_message = await enrich_message_with_user_info(
+                        slack_client, message
                     )
+                    enriched_messages.append(enriched_message)
 
-                result = "\n".join(formatted_messages)
-                logger.info(f"Read messages result: {result}")
-
-                return [TextContent(type="text", text=result)]
+                return [
+                    TextContent(
+                        type="text", text=json.dumps(enriched_messages, indent=2)
+                    )
+                ]
 
             elif name == "send_message":
                 if "channel" not in arguments or "text" not in arguments:
@@ -415,9 +414,10 @@ def create_server(user_id, api_key=None):
                         slack_client, server, channel_name
                     )
                     if channel_id is None:
+                        error_response = {"error": f"Channel {channel} not found"}
                         return [
                             TextContent(
-                                type="text", text=f"Channel {channel} not found"
+                                type="text", text=json.dumps(error_response, indent=2)
                             )
                         ]
                     channel = channel_id
@@ -426,8 +426,11 @@ def create_server(user_id, api_key=None):
                     user_name = channel[1:]
                     user_id = await get_user_id(slack_client, server, user_name)
                     if user_id is None:
+                        error_response = {"error": f"User {channel} not found"}
                         return [
-                            TextContent(type="text", text=f"User {channel} not found")
+                            TextContent(
+                                type="text", text=json.dumps(error_response, indent=2)
+                            )
                         ]
 
                     # Open DM channel
@@ -441,12 +444,14 @@ def create_server(user_id, api_key=None):
                     message_args["thread_ts"] = thread_ts
 
                 response = slack_client.chat_postMessage(**message_args)
-                return [
-                    TextContent(
-                        type="text",
-                        text=f"Message sent successfully to <#{channel}>\nTimestamp: {response['ts']}",
-                    )
-                ]
+                result = {
+                    "status": "success",
+                    "channel": channel,
+                    "ts": response["ts"],
+                    "message": response.get("message", {}),
+                }
+
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
             elif name == "create_canvas":
                 if not all(k in arguments for k in ["channel", "title", "blocks"]):
@@ -466,9 +471,10 @@ def create_server(user_id, api_key=None):
                         slack_client, server, channel_name
                     )
                     if channel_id is None:
+                        error_response = {"error": f"Channel {channel} not found"}
                         return [
                             TextContent(
-                                type="text", text=f"Channel {channel} not found"
+                                type="text", text=json.dumps(error_response, indent=2)
                             )
                         ]
                     channel = channel_id
@@ -478,9 +484,10 @@ def create_server(user_id, api_key=None):
                     try:
                         blocks = json.loads(blocks)
                     except json.JSONDecodeError:
+                        error_response = {"error": "Invalid JSON in blocks parameter"}
                         return [
                             TextContent(
-                                type="text", text="Invalid JSON in blocks parameter"
+                                type="text", text=json.dumps(error_response, indent=2)
                             )
                         ]
 
@@ -511,20 +518,25 @@ def create_server(user_id, api_key=None):
                     message_args["thread_ts"] = thread_ts
 
                 response = slack_client.chat_postMessage(**message_args)
+                result = {
+                    "status": "success",
+                    "channel": channel,
+                    "ts": response["ts"],
+                    "message": response.get("message", {}),
+                }
 
-                return [
-                    TextContent(
-                        type="text",
-                        text=f"Canvas created successfully in <#{channel}>\nTimestamp: {response['ts']}",
-                    )
-                ]
+                return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
             else:
-                raise ValueError(f"Unknown tool: {name}")
+                error_response = {"error": f"Unknown tool: {name}"}
+                return [
+                    TextContent(type="text", text=json.dumps(error_response, indent=2))
+                ]
 
         except SlackApiError as e:
             logger.error(f"Slack API error: {e}")
-            return [TextContent(type="text", text=f"Error: {str(e)}")]
+            error_response = {"error": str(e)}
+            return [TextContent(type="text", text=json.dumps(error_response, indent=2))]
 
     return server
 

--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -40,6 +40,9 @@ SCOPES = [
     "chat:write",
     "chat:write.customize",
     "users:read",
+    "groups:read",
+    "groups:write",
+    "groups:history",
 ]
 
 # Configure logging
@@ -259,6 +262,13 @@ def create_server(user_id, api_key=None):
                     },
                     "required": ["channel"],
                 },
+                outputSchema={
+                    "type": "string",
+                    "description": "Chronologically ordered list of messages in the format: [timestamp] user: message_text",
+                    "examples": [
+                        "[2025-04-28 16:17:15] U08L3MC1PPA: <@U08L3MC1PPA> has joined the channel\n[2025-04-28 16:17:33] U08Q6PK8S04: <@U08Q6PK8S04> has joined the channel\n[2025-04-28 16:55:31] U08Q6PK8S04: This is a test message from the MCP server!"
+                    ],
+                },
             ),
             Tool(
                 name="send_message",
@@ -280,6 +290,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                     "required": ["channel", "text"],
+                },
+                outputSchema={
+                    "type": "string",
+                    "description": "Confirmation message with channel ID and timestamp of the sent message",
+                    "examples": [
+                        "Message sent successfully to <#C08Q6PQQZSQ>\nTimestamp: 1745884854.985879"
+                    ],
                 },
             ),
             Tool(
@@ -306,6 +323,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                     "required": ["channel", "title", "blocks"],
+                },
+                outputSchema={
+                    "type": "string",
+                    "description": "Confirmation message with channel ID and timestamp of the created canvas",
+                    "examples": [
+                        "Canvas created successfully in <#C08Q6PQQZSQ>\nTimestamp: 1745884854.985879"
+                    ],
                 },
             ),
         ]

--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -273,7 +273,7 @@ def create_server(user_id, api_key=None):
                     "type": "string",
                     "description": "Chronologically ordered list of messages in the format: '<#channel_id> user_name: message_text'",
                     "examples": [
-                        "<#C08Q6PQQZSQ> testing_mcp: Test Canvas\n<#C08Q6PQQZSQ> testing_mcp: This is a test message from the MCP server!\n<#C08Q6PQQZSQ> Jyoti Swain: heyo"
+                        "<#C08Q6PQQZSQ> testing_mcp: Test Canvas\n<#C08Q6PQQZSQ> testing_mcp: This is a test message from the MCP server!\n<#C08Q6PQQZSQ> gumloop: heyo"
                     ],
                 },
             ),

--- a/src/servers/word/main.py
+++ b/src/servers/word/main.py
@@ -281,6 +281,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                 },
+                outputSchema={
+                    "type": "object",
+                    "description": "Returns an array of Word documents with their metadata including document IDs, names, web URLs, modification dates, and file sizes",
+                    "examples": [
+                        "{\n  \"documents\": []\n}"
+                    ],
+                },
             ),
             Tool(
                 name="create_document",
@@ -303,6 +310,13 @@ def create_server(user_id, api_key=None):
                     },
                     "required": ["name"],
                 },
+                outputSchema={
+                    "type": "object",
+                    "description": "Details of the newly created Word document including its ID, name, browser access URL, initial content, and storage location type",
+                    "examples": [
+                        "{\n  \"created_file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"web_url\": \"<web_url>\",\n  \"content\": \"\",\n  \"is_sharepoint\": false\n}"
+                    ],
+                },
             ),
             Tool(
                 name="read_document",
@@ -316,6 +330,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                     "required": ["file_id"],
+                },
+                outputSchema={
+                    "type": "object",
+                    "description": "Full text content of the document along with metadata including file ID, name, content size in bytes, and last modification timestamp",
+                    "examples": [
+                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"content\": \"Example document content\",\n  \"size\": 36582,\n  \"last_modified\": \"2025-04-29T19:30:16Z\"\n}"
+                    ],
                 },
             ),
             Tool(
@@ -334,6 +355,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                     "required": ["file_id", "content"],
+                },
+                outputSchema={
+                    "type": "object",
+                    "description": "Status of the document update operation including file identifier, document name, append confirmation, updated file size, and preview of the appended content",
+                    "examples": [
+                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"appended\": true,\n  \"size\": 36582,\n  \"content_preview\": \"Example content\"\n}"
+                    ],
                 },
             ),
             Tool(
@@ -354,6 +382,13 @@ def create_server(user_id, api_key=None):
                     },
                     "required": ["query"],
                 },
+                outputSchema={
+                    "type": "object",
+                    "description": "Search query results containing an array of matching documents, the ID of the first result (if any), and whether the documents are stored in SharePoint",
+                    "examples": [
+                        "{\n  \"documents\": [],\n  \"file_id\": \"\",\n  \"is_sharepoint\": false\n}"
+                    ],
+                },
             ),
             Tool(
                 name="download_document",
@@ -368,6 +403,13 @@ def create_server(user_id, api_key=None):
                     },
                     "required": ["file_id"],
                 },
+                outputSchema={
+                    "type": "object",
+                    "description": "Document download details including file ID, filename, direct download URL, file size in bytes, browser access URL, and the document's MIME type",
+                    "examples": [
+                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"url\": \"<download_url>\",\n  \"size\": 36582,\n  \"web_url\": \"<web_url>\",\n  \"mime_type\": \"application/vnd.openxmlformats-officedocument.wordprocessingml.document\"\n}"
+                    ],
+                },
             ),
             Tool(
                 name="delete_document",
@@ -381,6 +423,13 @@ def create_server(user_id, api_key=None):
                         },
                     },
                     "required": ["file_id"],
+                },
+                outputSchema={
+                    "type": "object",
+                    "description": "Result of the document deletion operation including confirmation of deletion, the ID of the deleted file, and overall success status",
+                    "examples": [
+                        "{\n  \"deleted\": true,\n  \"file_id\": \"<file_id>\",\n  \"success\": true\n}"
+                    ],
                 },
             ),
         ]

--- a/src/servers/word/main.py
+++ b/src/servers/word/main.py
@@ -284,9 +284,7 @@ def create_server(user_id, api_key=None):
                 outputSchema={
                     "type": "object",
                     "description": "Returns an array of Word documents with their metadata including document IDs, names, web URLs, modification dates, and file sizes",
-                    "examples": [
-                        "{\n  \"documents\": []\n}"
-                    ],
+                    "examples": ['{\n  "documents": []\n}'],
                 },
             ),
             Tool(
@@ -314,7 +312,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Details of the newly created Word document including its ID, name, browser access URL, initial content, and storage location type",
                     "examples": [
-                        "{\n  \"created_file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"web_url\": \"<web_url>\",\n  \"content\": \"\",\n  \"is_sharepoint\": false\n}"
+                        '{\n  "created_file_id": "<file_id>",\n  "name": "Test Document.docx",\n  "web_url": "<web_url>",\n  "content": "",\n  "is_sharepoint": false\n}'
                     ],
                 },
             ),
@@ -335,7 +333,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Full text content of the document along with metadata including file ID, name, content size in bytes, and last modification timestamp",
                     "examples": [
-                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"content\": \"Example document content\",\n  \"size\": 36582,\n  \"last_modified\": \"2025-04-29T19:30:16Z\"\n}"
+                        '{\n  "file_id": "<file_id>",\n  "name": "Test Document.docx",\n  "content": "Example document content",\n  "size": 36582,\n  "last_modified": "2025-04-29T19:30:16Z"\n}'
                     ],
                 },
             ),
@@ -360,7 +358,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Status of the document update operation including file identifier, document name, append confirmation, updated file size, and preview of the appended content",
                     "examples": [
-                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"appended\": true,\n  \"size\": 36582,\n  \"content_preview\": \"Example content\"\n}"
+                        '{\n  "file_id": "<file_id>",\n  "name": "Test Document.docx",\n  "appended": true,\n  "size": 36582,\n  "content_preview": "Example content"\n}'
                     ],
                 },
             ),
@@ -386,7 +384,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Search query results containing an array of matching documents, the ID of the first result (if any), and whether the documents are stored in SharePoint",
                     "examples": [
-                        "{\n  \"documents\": [],\n  \"file_id\": \"\",\n  \"is_sharepoint\": false\n}"
+                        '{\n  "documents": [],\n  "file_id": "",\n  "is_sharepoint": false\n}'
                     ],
                 },
             ),
@@ -407,7 +405,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Document download details including file ID, filename, direct download URL, file size in bytes, browser access URL, and the document's MIME type",
                     "examples": [
-                        "{\n  \"file_id\": \"<file_id>\",\n  \"name\": \"Test Document.docx\",\n  \"url\": \"<download_url>\",\n  \"size\": 36582,\n  \"web_url\": \"<web_url>\",\n  \"mime_type\": \"application/vnd.openxmlformats-officedocument.wordprocessingml.document\"\n}"
+                        '{\n  "file_id": "<file_id>",\n  "name": "Test Document.docx",\n  "url": "<download_url>",\n  "size": 36582,\n  "web_url": "<web_url>",\n  "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"\n}'
                     ],
                 },
             ),
@@ -428,7 +426,7 @@ def create_server(user_id, api_key=None):
                     "type": "object",
                     "description": "Result of the document deletion operation including confirmation of deletion, the ID of the deleted file, and overall success status",
                     "examples": [
-                        "{\n  \"deleted\": true,\n  \"file_id\": \"<file_id>\",\n  \"success\": true\n}"
+                        '{\n  "deleted": true,\n  "file_id": "<file_id>",\n  "success": true\n}'
                     ],
                 },
             ),


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR updates the Slack server by adding new group operation scopes and defining consistent output schemas for its tools. 

- Modified file: /src/servers/slack/main.py to include "groups:read", "groups:write", and "groups:history" scopes.
- Added output schema definitions for "read_messages", "send_message", and "create_canvas" tools.
- Schemas now accurately reflect the expected response formats as returned by the code.



<!-- /greptile_comment -->