### PR TITLE
resource test fix

### DIFF
--- a/tests/servers/excel/tests.py
+++ b/tests/servers/excel/tests.py
@@ -164,12 +164,13 @@ SHARED_CONTEXT = {}
 def context():
     return SHARED_CONTEXT
 
+
 @pytest.mark.asyncio
 async def test_resources(client):
     return await run_resources_test(client)
+
 
 @pytest.mark.parametrize("test_config", TOOL_TESTS, ids=get_test_id)
 @pytest.mark.asyncio
 async def test_excel_tool(client, context, test_config):
     return await run_tool_test(client, context, test_config)
-

--- a/tests/servers/excel/tests.py
+++ b/tests/servers/excel/tests.py
@@ -2,7 +2,7 @@ import pytest
 import re
 import random
 import string
-from tests.utils.test_tools import get_test_id, run_tool_test
+from tests.utils.test_tools import get_test_id, run_tool_test, run_resources_test
 
 
 TOOL_TESTS = [
@@ -164,52 +164,12 @@ SHARED_CONTEXT = {}
 def context():
     return SHARED_CONTEXT
 
+@pytest.mark.asyncio
+async def test_resources(client):
+    return await run_resources_test(client)
 
 @pytest.mark.parametrize("test_config", TOOL_TESTS, ids=get_test_id)
 @pytest.mark.asyncio
 async def test_excel_tool(client, context, test_config):
     return await run_tool_test(client, context, test_config)
 
-
-@pytest.mark.asyncio
-async def test_read_resource(client):
-    """Test reading an Excel workbook resource"""
-    # First list resources to get a valid Excel file
-    response = await client.list_resources()
-    assert (
-        response and hasattr(response, "resources") and len(response.resources)
-    ), f"Invalid list resources response: {response}"
-
-    # Find the first Excel file resource
-    excel_resource = next(
-        (r for r in response.resources if str(r.uri).startswith("excel://file/")),
-        None,
-    )
-
-    # Skip test if no Excel resources found
-    if not excel_resource:
-        pytest.skip("No Excel resources found to test read_resource functionality")
-        return
-
-    # Read Excel file details
-    response = await client.read_resource(excel_resource.uri)
-
-    # Verify response
-    assert response.contents, "Response should contain Excel workbook data"
-    assert response.contents[0].mimeType == "application/json", "Expected JSON response"
-
-    # Parse the JSON content
-    import json
-
-    content_text = response.contents[0].text
-    content_data = json.loads(content_text)
-
-    # Verify basic workbook data
-    assert "id" in content_data, "Response should include workbook ID"
-    assert "name" in content_data, "Response should include workbook name"
-    assert "worksheets" in content_data, "Response should include worksheets data"
-
-    print("Excel workbook data read:")
-    print(f"  - Workbook name: {content_data.get('name')}")
-    print(f"  - Worksheets count: {len(content_data.get('worksheets', []))}")
-    print("✅ Successfully read Excel workbook data")

--- a/tests/servers/word/tests.py
+++ b/tests/servers/word/tests.py
@@ -1,30 +1,7 @@
 import pytest
 import random
-from tests.utils.test_tools import get_test_id, run_tool_test
+from tests.utils.test_tools import get_test_id, run_tool_test, run_resources_test
 
-
-RESOURCE_TESTS = [
-    {
-        "name": "list_resources",
-        "expected_keywords": ["resources"],
-        "regex_extractors": {
-            "resource_uri": r'"?uri"?[:\s]+"?(word://file/[^"]+)"?',
-            "resource_name": r'"?name"?[:\s]+"?([^"]+)"?',
-        },
-        "description": "list Word document resources and extract a resource URI",
-    },
-    {
-        "name": "read_resource",
-        "args_template": 'with uri="{resource_uri}"',
-        "expected_keywords": ["contents"],
-        "regex_extractors": {
-            "document_id": r'"?id"?[:\s]+"?([^"]+)"?',
-            "document_name": r'"?name"?[:\s]+"?([^"]+)"?',
-        },
-        "description": "read a Word document resource and extract document details",
-        "depends_on": ["resource_uri"],
-    },
-]
 
 TOOL_TESTS = [
     {
@@ -87,16 +64,9 @@ TOOL_TESTS = [
 # Shared context dictionary at module level
 SHARED_CONTEXT = {}
 
-
 @pytest.fixture(scope="module")
 def context():
     return SHARED_CONTEXT
-
-
-@pytest.mark.parametrize("test_config", RESOURCE_TESTS, ids=get_test_id)
-@pytest.mark.asyncio
-async def test_word_resource(client, context, test_config):
-    return await run_tool_test(client, context, test_config)
 
 
 @pytest.mark.parametrize("test_config", TOOL_TESTS, ids=get_test_id)
@@ -106,34 +76,9 @@ async def test_word_tool(client, context, test_config):
 
 
 @pytest.mark.asyncio
-async def test_read_resource(client):
-    """Test reading a Word document resource"""
-    response = await client.list_resources()
+async def test_resources(client, context):
+    response = await run_resources_test(client)
+    context["first_resource_uri"] = response.resources[0].uri
+    return response
 
-    if not (response and hasattr(response, "resources") and len(response.resources)):
-        pytest.skip("No Word resources found to test read_resource functionality")
-        return
 
-    word_resource = next(
-        (r for r in response.resources if str(r.uri).startswith("word://file/")),
-        None,
-    )
-
-    if not word_resource:
-        pytest.skip("No Word resources found to test read_resource functionality")
-        return
-
-    response = await client.read_resource(word_resource.uri)
-    assert response.contents, "Response should contain Word document data"
-    assert response.contents[0].mimeType == "application/json", "Expected JSON response"
-
-    import json
-
-    content_data = json.loads(response.contents[0].text)
-
-    if "error" in content_data:
-        pytest.fail(f"Error reading document: {content_data.get('error')}")
-
-    assert "id" in content_data, "Response should include document ID"
-    assert "name" in content_data, "Response should include document name"
-    assert "webUrl" in content_data, "Response should include webUrl"

--- a/tests/servers/word/tests.py
+++ b/tests/servers/word/tests.py
@@ -64,6 +64,7 @@ TOOL_TESTS = [
 # Shared context dictionary at module level
 SHARED_CONTEXT = {}
 
+
 @pytest.fixture(scope="module")
 def context():
     return SHARED_CONTEXT
@@ -80,5 +81,3 @@ async def test_resources(client, context):
     response = await run_resources_test(client)
     context["first_resource_uri"] = response.resources[0].uri
     return response
-
-

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -6,21 +6,8 @@ def get_test_id(test_config):
     """Generate a unique test ID based on the test name and description hash"""
     return f"{test_config['name']}_{hash(test_config['description']) % 1000}"
 
-
-def validate_resource_uri(uri):
-    """
-    Validates that a resource URI follows the expected format: {server_id}://{resource_type}/{resource_id}
-    Returns a tuple of (is_valid, components) where components is (server_id, resource_type, resource_id)
-    """
-    pattern = r"^([a-zA-Z0-9_-]+)://([a-zA-Z0-9_-]+)/(.+)$"
-    match = re.match(pattern, uri)
-    if not match:
-        return False, None
-    return True, match.groups()
-
-
 @pytest.mark.asyncio
-async def run_tool_test(client, context, test_config):
+async def run_tool_test(client, context: dict, test_config: dict) -> dict:
     """
     Common test function for running tool tests across different servers.
 
@@ -28,6 +15,9 @@ async def run_tool_test(client, context, test_config):
         client: The client fixture
         context: Module-scoped context dictionary to store test values
         test_config: Configuration for the specific test to run
+        
+    Returns:
+        Updated context dictionary with test results
     """
     if test_config.get("skip", False):
         pytest.skip(f"Test {test_config['name']} marked to skip")
@@ -111,17 +101,26 @@ async def run_tool_test(client, context, test_config):
             if match and len(match.groups()) > 0:
                 context[key] = match.group(1).strip()
 
-    should_validate = test_config.get("validate_resource_uri", False) or (
-        tool_name in ["list_resources", "read_resource"] and "resource_uri" in context
-    )
-
-    if should_validate and "resource_uri" in context:
-        is_valid, components = validate_resource_uri(context["resource_uri"])
-        if is_valid:
-            context["resource_server"] = components[0]
-            context["resource_type"] = components[1]
-            context["resource_id"] = components[2]
-        else:
-            pytest.fail(f"Invalid resource URI format: {context['resource_uri']}")
-
     return context
+
+
+@pytest.mark.asyncio
+async def run_resources_test(client):
+    """
+    Generic test function for list_resources and read_resource handlers.
+    """
+    # List resources
+    response = await client.list_resources()
+    assert response and hasattr(response, "resources") and isinstance(response.resources, list), f"Invalid list_resources response: {response}"
+    if not response.resources:
+        pytest.skip("No resources found")
+
+    # Test only the first resource
+    resource = response.resources[0]
+    assert isinstance(resource.name, str) and resource.name, f"Invalid resource name for URI {resource.uri}"
+
+    contents = await client.read_resource(resource.uri)
+    assert hasattr(contents, "contents") and isinstance(contents.contents, list), f"Invalid read_resource response for {resource.uri}"
+    assert contents.contents, f"No content returned for {resource.uri}"
+
+    return response

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -6,6 +6,7 @@ def get_test_id(test_config):
     """Generate a unique test ID based on the test name and description hash"""
     return f"{test_config['name']}_{hash(test_config['description']) % 1000}"
 
+
 @pytest.mark.asyncio
 async def run_tool_test(client, context: dict, test_config: dict) -> dict:
     """
@@ -15,7 +16,7 @@ async def run_tool_test(client, context: dict, test_config: dict) -> dict:
         client: The client fixture
         context: Module-scoped context dictionary to store test values
         test_config: Configuration for the specific test to run
-        
+
     Returns:
         Updated context dictionary with test results
     """
@@ -111,16 +112,24 @@ async def run_resources_test(client):
     """
     # List resources
     response = await client.list_resources()
-    assert response and hasattr(response, "resources") and isinstance(response.resources, list), f"Invalid list_resources response: {response}"
+    assert (
+        response
+        and hasattr(response, "resources")
+        and isinstance(response.resources, list)
+    ), f"Invalid list_resources response: {response}"
     if not response.resources:
         pytest.skip("No resources found")
 
     # Test only the first resource
     resource = response.resources[0]
-    assert isinstance(resource.name, str) and resource.name, f"Invalid resource name for URI {resource.uri}"
+    assert (
+        isinstance(resource.name, str) and resource.name
+    ), f"Invalid resource name for URI {resource.uri}"
 
     contents = await client.read_resource(resource.uri)
-    assert hasattr(contents, "contents") and isinstance(contents.contents, list), f"Invalid read_resource response for {resource.uri}"
+    assert hasattr(contents, "contents") and isinstance(
+        contents.contents, list
+    ), f"Invalid read_resource response for {resource.uri}"
     assert contents.contents, f"No content returned for {resource.uri}"
 
     return response


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR standardizes resource testing across servers by replacing explicit resource tests with a unified run_resources_test helper, and updates documentation accordingly.  
- Modified /tests/servers/excel/tests.py to replace individual resource tests with run_resources_test.  
- Updated /tests/servers/word/tests.py to merge resource tests, simplifying checks.  
- Revamped /tests/README.md to align with the new testing framework.  
- Removed validate_resource_uri in /tests/utils/test_tools.py and ensured run_resources_test handles empty resource cases.



<!-- /greptile_comment -->