### PR TITLE
Auto-Restart start_sse_dev_server.sh on Server File Changes

### DIFF
--- a/scripts/server_watcher.py
+++ b/scripts/server_watcher.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import time
+import subprocess
+from pathlib import Path
+
+def get_file_mtimes(directory, pattern="*.py"):
+    result = {}
+    for path in Path(directory).rglob(pattern):
+        if path.is_file():
+            result[str(path)] = path.stat().st_mtime
+    return result
+
+def run_server():
+    cmd = [sys.executable, "src/servers/main.py"]
+    process = subprocess.Popen(cmd)
+    return process
+
+def watch_files():
+    servers_dir = "src/servers"
+    print(f"Watching for changes in {servers_dir}/*.py")
+    
+    mtimes = get_file_mtimes(servers_dir)
+    process = run_server()
+    
+    try:
+        while True:
+            time.sleep(1)
+            new_mtimes = get_file_mtimes(servers_dir)
+            
+            # Check for changed files
+            for file_path, mtime in new_mtimes.items():
+                if file_path not in mtimes or mtimes[file_path] != mtime:
+                    print(f"\nChange detected in {file_path}, restarting server...")
+                    process.terminate()
+                    process.wait()
+                    mtimes = new_mtimes
+                    process = run_server()
+                    break
+                    
+            # Check for new files
+            if set(new_mtimes.keys()) != set(mtimes.keys()):
+                print("\nNew or deleted files detected, restarting server...")
+                process.terminate()
+                process.wait()
+                mtimes = new_mtimes
+                process = run_server()
+    
+    except KeyboardInterrupt:
+        print("\nShutting down server...")
+        process.terminate()
+        sys.exit(0)
+
+if __name__ == "__main__":
+    watch_files() 

--- a/scripts/server_watcher.py
+++ b/scripts/server_watcher.py
@@ -4,6 +4,7 @@ import time
 import subprocess
 from pathlib import Path
 
+
 def get_file_mtimes(directory, pattern="*.py"):
     result = {}
     for path in Path(directory).rglob(pattern):
@@ -11,23 +12,25 @@ def get_file_mtimes(directory, pattern="*.py"):
             result[str(path)] = path.stat().st_mtime
     return result
 
+
 def run_server():
     cmd = [sys.executable, "src/servers/main.py"]
     process = subprocess.Popen(cmd)
     return process
 
+
 def watch_files():
     servers_dir = "src/servers"
     print(f"Watching for changes in {servers_dir}/*.py")
-    
+
     mtimes = get_file_mtimes(servers_dir)
     process = run_server()
-    
+
     try:
         while True:
             time.sleep(1)
             new_mtimes = get_file_mtimes(servers_dir)
-            
+
             # Check for changed files
             for file_path, mtime in new_mtimes.items():
                 if file_path not in mtimes or mtimes[file_path] != mtime:
@@ -37,7 +40,7 @@ def watch_files():
                     mtimes = new_mtimes
                     process = run_server()
                     break
-                    
+
             # Check for new files
             if set(new_mtimes.keys()) != set(mtimes.keys()):
                 print("\nNew or deleted files detected, restarting server...")
@@ -45,11 +48,12 @@ def watch_files():
                 process.wait()
                 mtimes = new_mtimes
                 process = run_server()
-    
+
     except KeyboardInterrupt:
         print("\nShutting down server...")
         process.terminate()
         sys.exit(0)
 
+
 if __name__ == "__main__":
-    watch_files() 
+    watch_files()

--- a/start_sse_dev_server.sh
+++ b/start_sse_dev_server.sh
@@ -15,14 +15,18 @@ fi
 export GUMCP_HOST=${GUMCP_HOST:-"0.0.0.0"}
 export GUMCP_PORT=${GUMCP_PORT:-"8000"}
 
-# Kill any process running on the specified port
-echo "Checking for processes running on port $GUMCP_PORT..."
-if lsof -i :$GUMCP_PORT > /dev/null; then
-    echo "Killing process running on port $GUMCP_PORT"
-    lsof -ti :$GUMCP_PORT | xargs kill -9
-    sleep 1
-fi
+# Function to kill server process
+kill_server() {
+    echo "Checking for processes running on port $GUMCP_PORT..."
+    if lsof -i :$GUMCP_PORT > /dev/null; then
+        echo "Killing process running on port $GUMCP_PORT"
+        lsof -ti :$GUMCP_PORT | xargs kill -9
+        sleep 1
+    fi
+}
 
-echo "Starting guMCP development server on $GUMCP_HOST:$GUMCP_PORT"
+# Kill any existing server process
+kill_server
 
-python src/servers/main.py
+echo "Starting guMCP development server on $GUMCP_HOST:$GUMCP_PORT with hot reloading"
+python scripts/server_watcher.py


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds a hot-reloading mechanism by introducing a new file watcher in scripts/server_watcher.py and integrates it into the dev startup script.

• Added scripts/server_watcher.py to recursively monitor src/servers/*.py and trigger server restarts on file changes.  
• Refactored start_sse_dev_server.sh to include a kill_server function to clear port conflicts before starting the watcher.  
• Uses forceful kill (-9) which may bypass graceful shutdowns; review stability under rapid file changes.



<!-- /greptile_comment -->