### PR TITLE
Fixing issues where array doesn't have items

### DIFF
--- a/src/servers/gsheets/main.py
+++ b/src/servers/gsheets/main.py
@@ -196,7 +196,7 @@ def create_server(user_id, api_key=None):
                     "properties": {
                         "spreadsheet_url": {"type": "string"},
                         "range": {"type": "string"},
-                        "values": {"type": "array", "items": {"type": "array"}},
+                        "values": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}},
                     },
                     "required": ["spreadsheet_url", "range", "values"],
                 },

--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -325,6 +325,7 @@ def create_server(user_id, api_key=None):
                         "blocks": {
                             "type": "array",
                             "description": "Array of Slack block kit elements as JSON objects",
+                            "items": {"type": "object"},
                         },
                         "thread_ts": {
                             "type": "string",


### PR DESCRIPTION
When using with OpenAI, there is a schema error for sheets and slack because of type array doesn't have the required values key

For Slack
```
openai.BadRequestError: Error code: 400 - {'statusCode': 400, 'error': {'message': "Invalid schema for function 'create_canvas': In context=('properties', 'blocks'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[6].function.parameters', 'code': 'invalid_function_parameters'}, 'message': 'Error from OpenAI API: Bad Request: {\n  "error": {\n    "message": "Invalid schema for function \'create_canvas\': In context=(\'properties\', \'blocks\'), array schema missing items.",\n    "type": "invalid_request_error",\n    "param": "tools[6].function.parameters",\n    "code": "invalid_function_parameters"\n  }\n}'}
```

For Sheets
```
openai.BadRequestError: Error code: 400 - {'statusCode': 400, 'error': {'message': "Invalid schema for function 'append-values': In context=('properties', 'values', 'items'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[5].function.parameters', 'code': 'invalid_function_parameters'}, 'message': 'Error from OpenAI API: Bad Request: {\n  "error": {\n    "message": "Invalid schema for function \'append-values\': In context=(\'properties\', \'values\', \'items\'), array schema missing items.",\n    "type": "invalid_request_error",\n    "param": "tools[5].function.parameters",\n    "code": "invalid_function_parameters"\n  }\n}'}
```