### PR TITLE
Fixing issues where array doesn't have items

### DIFF
--- a/src/servers/gsheets/main.py
+++ b/src/servers/gsheets/main.py
@@ -196,7 +196,7 @@ def create_server(user_id, api_key=None):
                     "properties": {
                         "spreadsheet_url": {"type": "string"},
                         "range": {"type": "string"},
-                        "values": {"type": "array", "items": {"type": "array"}},
+                        "values": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}},
                     },
                     "required": ["spreadsheet_url", "range", "values"],
                 },

--- a/src/servers/gsheets/main.py
+++ b/src/servers/gsheets/main.py
@@ -196,7 +196,10 @@ def create_server(user_id, api_key=None):
                     "properties": {
                         "spreadsheet_url": {"type": "string"},
                         "range": {"type": "string"},
-                        "values": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}},
+                        "values": {
+                            "type": "array",
+                            "items": {"type": "array", "items": {"type": "string"}},
+                        },
                     },
                     "required": ["spreadsheet_url", "range", "values"],
                 },

--- a/src/servers/slack/main.py
+++ b/src/servers/slack/main.py
@@ -325,6 +325,7 @@ def create_server(user_id, api_key=None):
                         "blocks": {
                             "type": "array",
                             "description": "Array of Slack block kit elements as JSON objects",
+                            "items": {"type": "object"},
                         },
                         "thread_ts": {
                             "type": "string",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request refines input schema validations in both Slack and Google Sheets servers to enforce stricter type-checking for critical tool inputs.

• Modified /src/servers/slack/main.py to add an "items" property for the 'blocks' array in the create_canvas tool, ensuring each block is an object.
• Updated /src/servers/gsheets/main.py so the 'append-values' tool only accepts arrays of arrays of strings.
• Verify that existing integrations correctly process these stricter schema constraints.



<!-- /greptile_comment -->